### PR TITLE
Preferred node affinity

### DIFF
--- a/charts/library-chart-tests/.helmignore
+++ b/charts/library-chart-tests/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/library-chart-tests/Chart.yaml
+++ b/charts/library-chart-tests/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: library-chart-tests
+description: A Helm chart for testing library chart
+
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+
+dependencies:
+  - name: library-chart
+    version: 4.3.0
+    repository: file://../library-chart

--- a/charts/library-chart-tests/templates/nodeaffinity.yaml
+++ b/charts/library-chart-tests/templates/nodeaffinity.yaml
@@ -1,0 +1,2 @@
+{{ include "library-chart.nodeAffinity" (dict "cpu" .Values.resources.cpu "memory" .Values.resources.memory) }}
+

--- a/charts/library-chart-tests/tests/nodeaffinity_test.yaml
+++ b/charts/library-chart-tests/tests/nodeaffinity_test.yaml
@@ -1,0 +1,53 @@
+suite: test deployment
+templates:
+  - nodeaffinity.yaml
+tests:
+
+  - it: Cpu is required
+    set:
+      resources:
+        memory: "2"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Argument must contain 'cpu' (in millicores)"
+  - it: Memory is required
+    set:
+      resources:
+        cpu: "2"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Argument must contain 'memory' (in Gi)"
+  - it: Should return empty when CPU and Memory is to large
+    set:
+      resources:
+        cpu: 80001
+        memory: 641
+    asserts:
+      - notFailedTemplate: {}
+      - hasDocuments:
+          count: 0
+  - it: Should return nodeAffinity when CPU and Memory is inside range
+    set:
+      resources:
+        cpu: 80000
+        memory: 640
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: nodeAffinity
+          value:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 80
+                preference:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-size
+                          operator: In
+                          values:
+                            - "xlarge"
+                        - key: node-type
+                          operator: In
+                          values:
+                            - "memory"
+

--- a/charts/library-chart-tests/values.yaml
+++ b/charts/library-chart-tests/values.yaml
@@ -1,0 +1,3 @@
+resources: {}
+  #   cpu: 100m
+  #   memory: 128Mi

--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 4.2.15
+version: 4.3.0
 type: library

--- a/charts/library-chart/templates/_nodeaffinity.tpl
+++ b/charts/library-chart/templates/_nodeaffinity.tpl
@@ -1,9 +1,9 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-We want to select the best node pool based on requested resources - i.e. prefer smalest node pool by memory -
-such that we can get the best utiliaztion of nodes which hopefully will mean lowest cost.
-We will use preferredNodeAffinity. Note that nodeSeelctor can be used togheter with this, to avoid scheduling on unwanted nodes.
+We want to select the best node pool based on requested resources - i.e. prefer smallest node pool by memory -
+such that we can get the best utilization of nodes which hopefully will mean lowest cost.
+We will use preferredNodeAffinity. Note that nodeSeelctor can be used together with this, to avoid scheduling on unwanted nodes.
 */}}
 {{- define "library-chart.nodeAffinity" -}}
 

--- a/charts/library-chart/templates/_nodeaffinity.tpl
+++ b/charts/library-chart/templates/_nodeaffinity.tpl
@@ -14,8 +14,8 @@ We will use preferredNodeAffinity. Note that nodeSeelctor can be used togheter w
 {{- $nodepools = append $nodepools (dict "name" "standard320gb" "cpu" 80000 "mem" 320 "labels" (dict "node-type" "cpu")) -}}
 {{- $nodepools = append $nodepools (dict "name" "highmem640gb" "cpu" 80000 "mem" 640 "labels" (dict "node-size" "xlarge" "node-type" "memory")) -}}
 
-{{- $requestedCpu := required "'.Values.resources.requests.cpu' is required (in millicores)" .Values.resources.requests.cpu | int -}}
-{{- $requestedMem := required "'.Values.resources.requests.memory' is required (in Gi)" .Values.resources.requests.memory | int -}}
+{{- $requestedCpu := required "Argument must contain 'cpu' (in millicores) " .cpu | int -}}
+{{- $requestedMem := required "Argument must contain 'memory' (in Gi)" .memory | int -}}
 {{- $optimalNodePoolLabels := dict -}}
 
 {{- range $nodepool := $nodepools -}}

--- a/charts/library-chart/templates/_nodeaffinity.tpl
+++ b/charts/library-chart/templates/_nodeaffinity.tpl
@@ -14,7 +14,7 @@ We will use preferredNodeAffinity. Note that nodeSeelctor can be used together w
 {{- $nodepools = append $nodepools (dict "name" "standard320gb" "cpu" 80000 "mem" 320 "labels" (dict "node-type" "cpu")) -}}
 {{- $nodepools = append $nodepools (dict "name" "highmem640gb" "cpu" 80000 "mem" 640 "labels" (dict "node-size" "xlarge" "node-type" "memory")) -}}
 
-{{- $requestedCpu := required "Argument must contain 'cpu' (in millicores) " .cpu | int -}}
+{{- $requestedCpu := required "Argument must contain 'cpu' (in millicores)" .cpu | int -}}
 {{- $requestedMem := required "Argument must contain 'memory' (in Gi)" .memory | int -}}
 {{- $optimalNodePoolLabels := dict -}}
 

--- a/charts/library-chart/templates/_nodeaffinity.tpl
+++ b/charts/library-chart/templates/_nodeaffinity.tpl
@@ -1,0 +1,42 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+We want to select the best node pool based on requested resources - i.e. prefer smalest node pool by memory -
+such that we can get the best utiliaztion of nodes which hopefully will mean lowest cost.
+We will use preferredNodeAffinity. Note that nodeSeelctor can be used togheter with this, to avoid scheduling on unwanted nodes.
+*/}}
+{{- define "library-chart.nodeAffinity" -}}
+
+{{- $nodepools := list -}}
+{{- /* Ordered by memory */ -}}
+{{- $nodepools = append $nodepools (dict "name" "highmem128gb" "cpu" 16000 "mem" 128 "labels" (dict "node-size" "medium" "node-type" "memory")) -}}
+{{- $nodepools = append $nodepools (dict "name" "highmem256gb" "cpu" 32000 "mem" 256 "labels" (dict "node-size" "large" "node-type" "memory")) -}}
+{{- $nodepools = append $nodepools (dict "name" "standard320gb" "cpu" 80000 "mem" 320 "labels" (dict "node-type" "cpu")) -}}
+{{- $nodepools = append $nodepools (dict "name" "highmem640gb" "cpu" 80000 "mem" 640 "labels" (dict "node-size" "xlarge" "node-type" "memory")) -}}
+
+{{- $requestedCpu := required "'.Values.resources.requests.cpu' is required (in millicores)" .Values.resources.requests.cpu | int -}}
+{{- $requestedMem := required "'.Values.resources.requests.memory' is required (in Gi)" .Values.resources.requests.memory | int -}}
+{{- $optimalNodePoolLabels := dict -}}
+
+{{- range $nodepool := $nodepools -}}
+  {{- /* Find the first nodepool in the list that has capacity  */ -}}
+  {{- if and (not $optimalNodePoolLabels) (le $requestedCpu $nodepool.cpu) (le $requestedMem $nodepool.mem) -}}
+    {{- $optimalNodePoolLabels = $nodepool.labels -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $optimalNodePoolLabels -}}
+nodeAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 80 {{- /* 80 is a bit random, but most to emphasise to k8s that this should really be considered */}}
+    preference:
+      nodeSelectorTerms:
+      - matchExpressions:
+        {{- range $key, $value := $optimalNodePoolLabels }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $value | quote }}
+        {{- end }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
We want to select the best node pool based on requested resources - i.e. prefer smalest node pool by memory such that we can get the best utilisation of nodes which hopefully will mean lowest cost.

Added unit test by introducing a chart that can be used for unit testing (since library chart is not supported natively in helm unittest (https://github.com/helm-unittest/helm-unittest)

Can be tested on local machine with: 
```
  - name: library-chart
    version: 4.3.0
    repository: file://../dapla-lab-helm-charts-library/charts/library-chart
```