### PR TITLE
Change OAuth2 Proxy image

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 4.4.6
+version: 4.4.7
 type: library

--- a/charts/library-chart/templates/_oauth2proxy_pod.tpl
+++ b/charts/library-chart/templates/_oauth2proxy_pod.tpl
@@ -11,7 +11,7 @@ return the pod configuration for oauth2-proxy which will run as a sidecar in our
 */}}
 {{- define "library-chart.oauth2ProxyPod" -}}
 name: oauth2-proxy
-image: bitnami/oauth2-proxy:7.8.2
+image: europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-platform-docker/oauth2-proxy:v7.8.2
 imagePullPolicy: IfNotPresent
 ports:
   - name: http-oauth2


### PR DESCRIPTION
Because of upcomming bitnami changes we have a copy of the bitnami oauth2-proxy image in our artifact registry, this changes to use that image.

Internal-ref: [DPSKY-1148]