### PR TITLE
feat: add probes template

### DIFF
--- a/charts/library-chart/Chart.yaml
+++ b/charts/library-chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: library-chart
-version: 4.6.1
+version: 4.7.0
 type: library

--- a/charts/library-chart/templates/_probes.tpl
+++ b/charts/library-chart/templates/_probes.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+We want liveness and readiness probes that do not cause the service to restart
+if it is doing some medium/heavy computing. We therefore define these with
+quite a high timeout and period. An eager startup probe is defined to mark the
+container as ready ASAP during startup.
+*/}}
+{{- define "library-chart.probes" -}}
+startupProbe:
+  httpGet:
+    path: /
+    port: {{ .Values.networking.service.port }}
+  failureThreshold: 60
+  periodSeconds: 5
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /
+    port: {{ .Values.networking.service.port }}
+    scheme: HTTP
+  periodSeconds: 60
+  successThreshold: 1
+  timeoutSeconds: 15
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /
+    port: {{ .Values.networking.service.port }}
+    scheme: HTTP
+  periodSeconds: 60
+  successThreshold: 1
+  timeoutSeconds: 15
+{{- end -}}


### PR DESCRIPTION
So that we can consolidate the probe configuration across services.
The values here are chosen to alleviate some of the restarting issued we've had with medium/heavy workloads.